### PR TITLE
Add workaround for current empty body parsing problem

### DIFF
--- a/src/transport/parse.rs
+++ b/src/transport/parse.rs
@@ -169,6 +169,7 @@ where
 {
     let body = str::from_utf8(chunk).map_err(Error::from)?;
     if status.is_success() {
+        let body = if body.is_empty() { "null" } else { body };
         de_from_str::<T>(body).map_err(|e| ErrorKind::DockerApiUnknown(e.to_string(), status))
     } else {
         Err(match de_from_str::<ErrorResponse>(body) {


### PR DESCRIPTION
According to:

https://docs-stage.docker.com/engine/api/v1.24/

Method `STOP A CONTAINER` has a response:
```
HTTP/1.1 204 No Content
```

with empty body. This PR introduces a hacky workaround to solve it. 

See: https://github.com/golemfactory/golem-unlimited/issues/212